### PR TITLE
[BUG-FIX] Uneven spacing when in compact displayMode

### DIFF
--- a/lib/src/side_menu_item.dart
+++ b/lib/src/side_menu_item.dart
@@ -144,8 +144,8 @@ class _SideMenuItemState extends State<SideMenuItem> {
                       width: Global.style.itemInnerSpacing,
                     ),
                     _generateIcon(widget.icon),
-                    const SizedBox(
-                      width: 8.0,
+                    SizedBox(
+                      width: Global.style.itemInnerSpacing,
                     ),
                     if (value == SideMenuDisplayMode.open)
                       Expanded(


### PR DESCRIPTION
Hello friend, can you merge this? I just fixed the bug where there was uneven spacing when the sidemenu was set to compact, so I just overrode hard-set value to my, custom variable, added in the last PR. Thanks.

Signed by [Branislav Mateáš](https://github.com/BranislavMateas).