### PR TITLE
feat: add selectedHoverColor property

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -57,6 +57,13 @@ class _MyHomePageState extends State<MyHomePage> {
               // showTooltip: false,
               displayMode: SideMenuDisplayMode.auto,
               hoverColor: Colors.blue[100],
+              selectedHoverColor: Color.alphaBlend(
+                  Color.fromRGBO(
+                      Theme.of(context).colorScheme.surfaceTint.red,
+                      Theme.of(context).colorScheme.surfaceTint.green,
+                      Theme.of(context).colorScheme.surfaceTint.blue,
+                      0.08),
+                  Colors.blue[100]!),
               selectedColor: Colors.lightBlue,
               selectedTitleTextStyle: const TextStyle(color: Colors.white),
               selectedIconColor: Colors.white,

--- a/lib/src/side_menu_item.dart
+++ b/lib/src/side_menu_item.dart
@@ -127,7 +127,13 @@ class _SideMenuItemState extends State<SideMenuItem> {
   /// Set background color of [SideMenuItem]
   Color _setColor() {
     if (widget.priority == currentPage) {
-      return Global.style.selectedColor ?? Theme.of(context).highlightColor;
+      if (isHovered) {
+        return Global.style.selectedHoverColor ??
+            Global.style.selectedColor ??
+            Theme.of(context).highlightColor;
+      } else {
+        return Global.style.selectedColor ?? Theme.of(context).highlightColor;
+      }
     } else if (isHovered) {
       return Global.style.hoverColor ?? Colors.transparent;
     } else {

--- a/lib/src/side_menu_style.dart
+++ b/lib/src/side_menu_style.dart
@@ -17,6 +17,9 @@ class SideMenuStyle {
   /// Color of [SideMenuItem] when mouse hover on that
   Color? hoverColor;
 
+  /// Color of [SideMenuItem] when mouse hover on that an it is selected
+  Color? selectedHoverColor;
+
   /// You can use the [displayMode] property to configure different
   /// display modes for the [SideMenu]
   SideMenuDisplayMode? displayMode;
@@ -67,6 +70,7 @@ class SideMenuStyle {
     this.backgroundColor,
     this.selectedColor,
     this.hoverColor = Colors.transparent,
+    this.selectedHoverColor,
     this.displayMode = SideMenuDisplayMode.auto,
     this.selectedTitleTextStyle,
     this.unselectedTitleTextStyle,


### PR DESCRIPTION
This change introduces a new property to configure the color when the mouse pointer is moved over a selected side menu item.
The change is non-breaking. If the selectedHoverColor property is not configured the selectColor will be used.
The example has been adapted to showcase this property.
The reason for introducing this change is to style it according to Material 3 guidelines.