### PR TITLE
fix: avoid text wrap in menu item animation

### DIFF
--- a/lib/src/side_menu_item.dart
+++ b/lib/src/side_menu_item.dart
@@ -193,13 +193,17 @@ class _SideMenuItemState extends State<SideMenuItem> {
                         ),
                         if (value == SideMenuDisplayMode.open) ...[
                           Expanded(
-                            child: Text(
-                              widget.title ?? '',
-                              style: widget.priority == currentPage.ceil()
-                                  ? const TextStyle(fontSize: 17, color: Colors.black)
-                                      .merge(Global.style.selectedTitleTextStyle)
-                                  : const TextStyle(fontSize: 17, color: Colors.black54)
-                                      .merge(Global.style.unselectedTitleTextStyle),
+                            child: FittedBox(
+                              alignment: Alignment.centerLeft,
+                              fit: BoxFit.scaleDown,
+                              child: Text(
+                                widget.title ?? '',
+                                style: widget.priority == currentPage.ceil()
+                                    ? const TextStyle(fontSize: 17, color: Colors.black)
+                                        .merge(Global.style.selectedTitleTextStyle)
+                                    : const TextStyle(fontSize: 17, color: Colors.black54)
+                                        .merge(Global.style.unselectedTitleTextStyle),
+                              ),
                             ),
                           ),
                           if (widget.trailing != null && Global.showTrailing) ...[


### PR DESCRIPTION
During the animated expansion of the side menu, an ugly text wrap happens:
![image](https://user-images.githubusercontent.com/22014606/222899792-93ce4d95-cdcb-4a73-bcaa-dc4cfd90bb16.png)
This PR fixes that by wrapping the side menu items in a fitted box.
This will create a much nicer animation as the text will be bigger until it reaches its intended size:
![image](https://user-images.githubusercontent.com/22014606/222899762-ea04d6cd-96e5-49fd-ab8c-a3d31599575a.png)
