### PR TITLE
Update side_menu_item.dart - typo in the function isSameWidget()

### DIFF
--- a/lib/src/side_menu_item.dart
+++ b/lib/src/side_menu_item.dart
@@ -110,7 +110,7 @@ class _SideMenuItemState extends State<SideMenuItem> {
 
   bool isSameWidget(SideMenuItem other) {
     if (other.icon == widget.icon &&
-        other.title == other.title &&
+        other.title == widget.title &&
         other.builder == widget.builder &&
         other.trailing == widget.trailing) {
       return true;


### PR DESCRIPTION
There seems to be a typo here `other.title == other.title `