### PR TITLE
fix: Issue 50  + added safeSetState + Disposal of HandleChange listener

### DIFF
--- a/lib/src/global/global.dart
+++ b/lib/src/global/global.dart
@@ -1,5 +1,5 @@
 import 'dart:async';
-
+import 'package:flutter/scheduler.dart';
 import 'package:easy_sidemenu/src/side_menu_display_mode.dart';
 import 'package:easy_sidemenu/src/side_menu_item.dart';
 import 'package:easy_sidemenu/src/side_menu_style.dart';
@@ -49,7 +49,9 @@ class DisplayModeNotifier extends ValueNotifier<SideMenuDisplayMode> {
   DisplayModeNotifier(SideMenuDisplayMode value) : super(value);
 
   void change(SideMenuDisplayMode mode) {
-    value = mode;
-    notifyListeners();
+    SchedulerBinding.instance!.addPostFrameCallback((timeStamp) {
+      value = mode;
+      notifyListeners();
+    });
   }
 }


### PR DESCRIPTION
- This PR includes the changes proposed in [PR 64](https://github.com/Jamalianpour/easy_sidemenu/pull/64)

- Fixed [Issue 50](https://github.com/Jamalianpour/easy_sidemenu/issues/50)

- Added safeSetState - To intelligently handle multiple setState calls without checking the mounted condition for each of them one by one

- Handled Disposal of HandleChange listener properly to remove error -  setState() called after dispose() . This error appeared after making the ScheduledBinding change in global.dart

These issues were observed while using multiple sideMenus and transitioning between them.