### PR TITLE
SideMenuExpansionItem can now accept an initialExpanded parameter

### DIFF
--- a/lib/src/side_menu.dart
+++ b/lib/src/side_menu.dart
@@ -93,6 +93,10 @@ class SideMenu extends StatefulWidget {
         );
       } else if (data is SideMenuExpansionItem) {
         sideMenuExpansionItemIndex = sideMenuExpansionItemIndex + 1;
+        if (data.initialExpanded != null) {
+          global.expansionStateList[sideMenuExpansionItemIndex] =
+              data.initialExpanded!;
+        }
         return SideMenuExpansionItemWithGlobal(
           global: global,
           title: data.title,

--- a/lib/src/side_menu_expansion_item.dart
+++ b/lib/src/side_menu_expansion_item.dart
@@ -23,12 +23,17 @@ class SideMenuExpansionItem {
 
   final List<SideMenuItem> children;
 
+  /// Control whether or not the SideMenuExpansion should be expanded initialy or not.
+  /// Default is collabsed
+  final bool? initialExpanded;
+
   const SideMenuExpansionItem({
     Key? key,
     this.onTap,
     this.title,
     this.icon,
     this.iconWidget,
+    this.initialExpanded,
     required this.children,
   })  : assert(title != null || icon != null,
             'Title and icon should not be empty at the same time'),


### PR DESCRIPTION
- `initialExpanded` parameter allows user to control the initial expansion state of `SideMenuExpansionItem`.
- This feature is implemented by altering the initial expansion state inside `global.expansionStateList`.