### PR TITLE
export side_menu_item_type

### DIFF
--- a/lib/easy_sidemenu.dart
+++ b/lib/easy_sidemenu.dart
@@ -6,3 +6,4 @@ export 'package:easy_sidemenu/src/side_menu_display_mode.dart';
 export 'package:easy_sidemenu/src/side_menu_item.dart';
 export 'package:easy_sidemenu/src/side_menu_expansion_item.dart';
 export 'package:easy_sidemenu/src/side_menu_style.dart';
+export 'package:easy_sidemenu/src/models/side_menu_item_type.dart';


### PR DESCRIPTION
I have a custom function to generate the list of items to use with the SideMenu which is based on the current Auth status ( to limit user access to certain menus. 

This previously worked with a List<dynamic> but now requires List<SideMenuItemType> however the class SideMenuItemType is not being exported and so could not be accessed. 